### PR TITLE
Prevent xml exceptions when transmitting ']]>' in strings.

### DIFF
--- a/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/PotentialTest.cs
+++ b/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/PotentialTest.cs
@@ -54,6 +54,95 @@ namespace Deveel.Web.Deveel.Web.Zoho
 
             records = client.BulkUpsertRecords(_potentials);
         }
-    }
 
+        [Test]
+        public void should_send_data_in_cdata_block()
+        {
+            // Arrange
+            var zohoOrder = new ZohoPotential(Guid.NewGuid().ToString());
+            zohoOrder.SetValue("test", "---some-data---");
+
+            // Act
+            var collection = new ZohoEntityCollection<ZohoPotential>{ zohoOrder };
+            
+            // Assert
+            string xml = null;
+            Assert.DoesNotThrow(() => xml = collection.ToXmlString());
+            
+            Assert.That(xml, Is.Not.Null);
+            Assert.That(xml.Contains("<FL val=\"test\"><![CDATA[---some-data---]]></FL>"));
+        }
+
+        [Test]
+        public void should_not_include_null_value()
+        {
+            // Arrange
+            var zohoOrder = new ZohoPotential(Guid.NewGuid().ToString());
+            zohoOrder.SetValue("test", null);
+
+            // Act
+            var collection = new ZohoEntityCollection<ZohoPotential>{ zohoOrder };
+            
+            // Assert
+            string xml = null;
+            Assert.DoesNotThrow(() => xml = collection.ToXmlString());
+            
+            Assert.That(xml, Is.Not.Null);
+            Assert.That(xml.Contains("<FL val=\"test\">"), Is.False);
+        }
+
+        [Test]
+        public void should_create_empty_tag_with_empty_string()
+        {
+            // Arrange
+            var zohoOrder = new ZohoPotential(Guid.NewGuid().ToString());
+            zohoOrder.SetValue("test", "");
+
+            // Act
+            var collection = new ZohoEntityCollection<ZohoPotential>{ zohoOrder };
+            
+            // Assert
+            string xml = null;
+            Assert.DoesNotThrow(() => xml = collection.ToXmlString());
+            
+            Assert.That(xml, Is.Not.Null);
+            Assert.That(xml.Contains("<FL val=\"test\" />"));
+        }
+
+        [Test]
+        public void should_handle_invalid_cdata_string()
+        {
+            // Arrange
+            var zohoOrder = new ZohoPotential(Guid.NewGuid().ToString());
+            zohoOrder.SetValue("test", "---]]>---");  // Cannot have ']]>' inside an XML CDATA block
+
+            // Act
+            var collection = new ZohoEntityCollection<ZohoPotential>{ zohoOrder };
+            
+            // Assert
+            string xml = null;
+            Assert.DoesNotThrow(() => xml = collection.ToXmlString());
+            
+            Assert.That(xml, Is.Not.Null);
+            Assert.That(xml.Contains("<FL val=\"test\"><![CDATA[---]]>]]&gt;<![CDATA[---]]></FL>"), "Should have separate CData blocks with escaped ']]>'");
+        }
+
+        [Test]
+        public void should_handle_multiple_invalid_cdata_string()
+        {
+            // Arrange
+            var zohoOrder = new ZohoPotential(Guid.NewGuid().ToString());
+            zohoOrder.SetValue("test", "]]>---]]>---]]>");  // Cannot have ']]>' inside an XML CDATA block
+
+            // Act
+            var collection = new ZohoEntityCollection<ZohoPotential>{ zohoOrder };
+            
+            // Assert
+            string xml = null;
+            Assert.DoesNotThrow(() => xml = collection.ToXmlString());
+            
+            Assert.That(xml, Is.Not.Null);
+            Assert.That(xml.Contains("<FL val=\"test\">]]&gt;<![CDATA[---]]>]]&gt;<![CDATA[---]]>]]&gt;</FL>"), "Should have separate CData blocks with escaped ']]>'");
+        }
+    }
 }

--- a/src/Deveel.ZohoCRM/Deveel.Web.Zoho/ZohoEntity.cs
+++ b/src/Deveel.ZohoCRM/Deveel.Web.Zoho/ZohoEntity.cs
@@ -288,8 +288,20 @@ namespace Deveel.Web.Zoho {
 					// for the moment we always use CDATA to avoid errors given by
 					// invalid XML strings... in a later version we'll map this against
 					// the field type ...
-					fieldElement.Add(new XCData((string)value));
-				}
+
+                    // Need to split CData blocks by "]]>", since they can't be escaped within
+                    var parts = ((string) value).Split(new [] { "]]>" }, StringSplitOptions.None).ToArray();
+
+                    for (var i = 0; i < parts.Length; i++)
+                    {
+                        if (parts[i] != "")
+                            fieldElement.Add(new XCData(parts[i]));
+
+                        // Put back "]]>" as strings
+                        if (i != parts.Length - 1)
+                            fieldElement.Add("]]>");
+                    }
+                }
 
 				rowElement.Add(fieldElement);
 			}			


### PR DESCRIPTION
Transmitting ']]>' to Zoho would throw an exception previously.  This is because an Xml CData block cannot have ']]>' inside it.

Since there is no way to escape the content, the fix is to use multiple CData blocks - having the ']]>' appear outside.

I added tests to cover the various cases.  Note there is a change of behaviour with empty strings which would previously result in an empty CData block: now there is no CData block added.  I opted to roll with this since it's benign and keeps the code simpler.