### PR TITLE
PP-2152 Fix for boolean values

### DIFF
--- a/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/EntityTestBase.cs
+++ b/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/EntityTestBase.cs
@@ -155,5 +155,34 @@ namespace Deveel.Web.Zoho {
 			var content = memoryStream.ToArray();
 			return content;
 		}
-	}
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShouldStoreBooleansInLowerCase(bool value)
+        {
+            // Arrange
+            var client = new ZohoContact("some.email@partpay.co.nz");
+
+            // Act
+            client.SetValue("EmailOptOut", value);
+
+            // Assert
+            var expected = value ? value.ToString().ToLower() : null;
+            Assert.That(client.GetValue<string>("EmailOptOut"), Is.EqualTo(value.ToString().ToLower()));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShouldRestoreBooleansValue(bool value)
+        {
+            // Arrange
+            var client = new ZohoContact("some.email@partpay.co.nz");
+
+            // Act
+            client.SetValue("EmailOptOut", value);
+
+            // Assert
+            Assert.That(client.GetValue<bool>("EmailOptOut"), Is.EqualTo(value));
+        }
+    }
 }

--- a/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/EntityTestBase.cs
+++ b/src/Deveel.ZohoCRM.Tests/Deveel.Web.Zoho/EntityTestBase.cs
@@ -167,7 +167,6 @@ namespace Deveel.Web.Zoho {
             client.SetValue("EmailOptOut", value);
 
             // Assert
-            var expected = value ? value.ToString().ToLower() : null;
             Assert.That(client.GetValue<string>("EmailOptOut"), Is.EqualTo(value.ToString().ToLower()));
         }
 

--- a/src/Deveel.ZohoCRM.Tests/Deveel.ZohoCRM.Tests.csproj
+++ b/src/Deveel.ZohoCRM.Tests/Deveel.ZohoCRM.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -86,6 +87,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Deveel.ZohoCRM.Tests/packages.config
+++ b/src/Deveel.ZohoCRM.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.11.0" targetFramework="net35" requireReinstallation="true" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net461" />
 </packages>

--- a/src/Deveel.ZohoCRM/Deveel.Web.Zoho/ZohoEntity.cs
+++ b/src/Deveel.ZohoCRM/Deveel.Web.Zoho/ZohoEntity.cs
@@ -169,7 +169,12 @@ namespace Deveel.Web.Zoho {
 			SetValue<DateTime>(fieldName, value);
 		}
 
-		public string GetString(string fieldName) {
+        public void SetValue(string fieldName, bool value)
+        {
+            SetValue<string>(fieldName, value.ToString().ToLower());
+        }
+
+        public string GetString(string fieldName) {
 			return GetValue<string>(fieldName);
 		}
 


### PR DESCRIPTION
The issue is that booleans are converted to strings "True"/"False" but they're case-sensitive and need to go in as "true"/"false".

A boolean-specific overload has been added & tests put around it.

Added NUnit3TestAdapter so unit tests run without Resharper.
